### PR TITLE
fix: combina chaves repetidas ("social") no _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,12 +51,25 @@ facebook:
 
 social:
   name: "Silo - Arte e Latitude Rural"
+  instagram: "https://www.instagram.com/silo.arte.e.latitude.rural"
+  facebook: "https://www.facebook.com/silo.arte.latitude.rural"
+  twitter: ""
+  flickr: ""
+  github: "https://github.com/associacaosilo"
+  youtube: "https://www.youtube.com/@SiloArteeLatitudeRural"
+  vimeo: ""
+  soundcloud: ""
+  tumblr: ""
+  pinterest: ""
+  linkedin: "https://www.linkedin.com/company/silo-arte-e-latitude-rural"
+  envelope-o: "mailto:contato@silo.org.br"
   links:
     - "https://www.instagram.com/silo.arte.e.latitude.rural"
     - "https://www.facebook.com/silo.arte.latitude.rural"
     - "https://github.com/associacaosilo"
     - "https://www.youtube.com/@SiloArteeLatitudeRural"
     - "https://www.linkedin.com/company/silo-arte-e-latitude-rural"
+  
 
 safe: true
 
@@ -78,20 +91,6 @@ defaults:
       path: "media/docs"
     values:
       layout: null
-
-social:
-  instagram: "https://www.instagram.com/silo.arte.e.latitude.rural"
-  facebook: "https://www.facebook.com/silo.arte.latitude.rural"
-  twitter: ""
-  flickr: ""
-  github: "https://github.com/associacaosilo"
-  youtube: "https://www.youtube.com/@SiloArteeLatitudeRural"
-  vimeo: ""
-  soundcloud: ""
-  tumblr: ""
-  pinterest: ""
-  linkedin: "https://www.linkedin.com/company/silo-arte-e-latitude-rural"
-  envelope-o: "mailto:contato@silo.org.br"
 
 twitter_user: "SiloLatitude"
 


### PR DESCRIPTION
A chave _social_ estava repetida no _config.yml. Aparentemente é válido, e o yaml é cumulativo (?), mas me parece confuso.